### PR TITLE
Switch to use semver library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # simple-update-notifier
 
-Simple update notifier to check for npm updates for cli applications with zero dependencies.
+Simple update notifier to check for npm updates for cli applications.
 
 <img src="./.github/demo.png" alt="Demo in terminal showing an update is required">
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "prepare": "yarn lint && yarn build",
     "release": "release-it"
   },
+  "dependencies": {
+    "semver": "^7.3.7"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-typescript": "^7.17.12",

--- a/src/hasNewVersion.spec.ts
+++ b/src/hasNewVersion.spec.ts
@@ -1,4 +1,4 @@
-import hasNewVersion, { isVersionNewer } from './hasNewVersion';
+import hasNewVersion from './hasNewVersion';
 import { getLastUpdate } from './cache';
 import getDistVersion from './getDistVersion';
 
@@ -13,12 +13,14 @@ const pkg = { name: 'test', version: '1.0.0' };
 
 afterEach(() => jest.clearAllMocks());
 
+const defaultArgs = {
+  pkg,
+  shouldNotifyInNpmScript: true,
+  alwaysRun: true,
+};
+
 test('it should not trigger update for same version', async () => {
-  const newVersion = await hasNewVersion({
-    pkg,
-    shouldNotifyInNpmScript: true,
-    alwaysRun: true,
-  });
+  const newVersion = await hasNewVersion(defaultArgs);
 
   expect(newVersion).toBe(false);
 });
@@ -26,11 +28,7 @@ test('it should not trigger update for same version', async () => {
 test('it should trigger update for patch version bump', async () => {
   (getDistVersion as jest.Mock).mockReturnValue('1.0.1');
 
-  const newVersion = await hasNewVersion({
-    pkg,
-    shouldNotifyInNpmScript: true,
-    alwaysRun: true,
-  });
+  const newVersion = await hasNewVersion(defaultArgs);
 
   expect(newVersion).toBe('1.0.1');
 });
@@ -38,11 +36,7 @@ test('it should trigger update for patch version bump', async () => {
 test('it should trigger update for minor version bump', async () => {
   (getDistVersion as jest.Mock).mockReturnValue('1.1.0');
 
-  const newVersion = await hasNewVersion({
-    pkg,
-    shouldNotifyInNpmScript: true,
-    alwaysRun: true,
-  });
+  const newVersion = await hasNewVersion(defaultArgs);
 
   expect(newVersion).toBe('1.1.0');
 });
@@ -50,11 +44,7 @@ test('it should trigger update for minor version bump', async () => {
 test('it should trigger update for major version bump', async () => {
   (getDistVersion as jest.Mock).mockReturnValue('2.0.0');
 
-  const newVersion = await hasNewVersion({
-    pkg,
-    shouldNotifyInNpmScript: true,
-    alwaysRun: true,
-  });
+  const newVersion = await hasNewVersion(defaultArgs);
 
   expect(newVersion).toBe('2.0.0');
 });
@@ -62,11 +52,7 @@ test('it should trigger update for major version bump', async () => {
 test('it should not trigger update if version is lower', async () => {
   (getDistVersion as jest.Mock).mockReturnValue('0.0.9');
 
-  const newVersion = await hasNewVersion({
-    pkg,
-    shouldNotifyInNpmScript: true,
-    alwaysRun: true,
-  });
+  const newVersion = await hasNewVersion(defaultArgs);
 
   expect(newVersion).toBe(false);
 });
@@ -93,43 +79,4 @@ it('should not trigger update check if last update is too recent', async () => {
 
   expect(newVersion).toBe(false);
   expect(getDistVersion).not.toHaveBeenCalled();
-});
-
-describe('isVersionNewer', () => {
-  test('returns true for patch increase', () => {
-    expect(isVersionNewer('1.0.0', '1.0.1')).toBe(true);
-  });
-  test('returns true for minor increase', () => {
-    expect(isVersionNewer('1.0.0', '1.1.0')).toBe(true);
-  });
-  test('returns true for major increase', () => {
-    expect(isVersionNewer('1.0.0', '2.0.0')).toBe(true);
-  });
-  test('returns true for patch increase ignoring prerelease flag', () => {
-    expect(isVersionNewer('1.0.0-development', '1.0.1')).toBe(true);
-  });
-  test('returns false for same version', () => {
-    expect(isVersionNewer('1.0.0', '1.0.0')).toBe(false);
-  });
-  test('returns true for same release version but without prerelease flag', () => {
-    expect(isVersionNewer('1.0.0-development', '1.0.0')).toBe(true);
-  });
-  test('returns true for check prerelease version', () => {
-    expect(isVersionNewer('1.0.0-1', '1.0.0-rc.2')).toBe(true);
-  });
-  test('returns true for higher prerelease version', () => {
-    expect(isVersionNewer('1.0.0-rc.1', '1.0.0-rc.2')).toBe(true);
-  });
-  test('returns false for lower prerelease version', () => {
-    expect(isVersionNewer('1.0.0-rc.2', '1.0.0-rc.1')).toBe(false);
-  });
-  test('returns false for lower patch version', () => {
-    expect(isVersionNewer('1.0.1', '1.0.0')).toBe(false);
-  });
-  test('returns false for lower minor version', () => {
-    expect(isVersionNewer('1.1.0', '1.0.0')).toBe(false);
-  });
-  test('returns false for lower minor version', () => {
-    expect(isVersionNewer('2.0.0', '1.0.0')).toBe(false);
-  });
 });

--- a/src/hasNewVersion.ts
+++ b/src/hasNewVersion.ts
@@ -1,28 +1,7 @@
+import semver from 'semver';
 import { createConfigDir, getLastUpdate, saveLastUpdate } from './cache';
 import getDistVersion from './getDistVersion';
 import { IUpdate } from './types';
-
-export const isVersionNewer = (oldVersion: string, newVersion: string) => {
-  const vOld = oldVersion.split('-');
-  const vNew = newVersion.split('-');
-  const oldVersionArray = vOld[0].split('.');
-  const newVersionArray = vNew[0].split('.');
-  for (let i = 0; i < oldVersionArray.length; i++) {
-    if (Number(oldVersionArray[i]) < Number(newVersionArray[i])) {
-      return true;
-    } else if (Number(oldVersionArray[i]) > Number(newVersionArray[i])) {
-      return false;
-    }
-  }
-  const preOldArray = (vOld[1] || '').split('.');
-  const preNewArray = (vNew[1] || '').split('.');
-  const preOld = preOldArray[1] || preOldArray[0];
-  const preNew = preNewArray[1] || preNewArray[0];
-  if ((vOld[1] && !vNew[1]) || Number(preOld) < Number(preNew)) {
-    return true;
-  }
-  return false;
-};
 
 const hasNewVersion = async ({
   pkg,
@@ -39,7 +18,7 @@ const hasNewVersion = async ({
   ) {
     const latestVersion = await getDistVersion(pkg.name, distTag);
     saveLastUpdate(pkg.name);
-    if (isVersionNewer(pkg.version, latestVersion)) {
+    if (semver.gt(latestVersion, pkg.version)) {
       return latestVersion;
     }
     return false;


### PR DESCRIPTION
Switching to use `semver` library as the version checking is starting to get quite complicated and is still not complete (for versions like `1.1` -> `1.0.1`)