### PR TITLE
Consolidating logic

### DIFF
--- a/src/hasNewVersion.ts
+++ b/src/hasNewVersion.ts
@@ -21,10 +21,9 @@ const hasNewVersion = async ({
     if (semver.gt(latestVersion, pkg.version)) {
       return latestVersion;
     }
-    return false;
-  } else {
-    return false;
   }
+  
+  return false;
 };
 
 export default hasNewVersion;

--- a/src/hasNewVersion.ts
+++ b/src/hasNewVersion.ts
@@ -22,7 +22,7 @@ const hasNewVersion = async ({
       return latestVersion;
     }
   }
-  
+
   return false;
 };
 


### PR DESCRIPTION
It seems that these two `return false` lines are redundant. There's only one path that can return a truthy value, any other path returns false.