### PR TITLE
Add `debug` flag to `simpleUpdateNotifier()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Type: `string`
 
 Type: `number`\
 Default: `1000 * 60 * 60 * 24` _(1 day)_
+
 How often to check for updates.
 
 #### shouldNotifyInNpmScript
@@ -65,3 +66,17 @@ Type: `string`\
 Default: `'latest'`
 
 Which [dist-tag](https://docs.npmjs.com/adding-dist-tags-to-packages) to use to find the latest version.
+
+#### alwaysRun
+
+Type: `boolean`\
+Default: `false`
+
+When set, `updateCheckInterval` will not be respected and a check for an update will always be performed.
+
+#### debug
+
+Type: `boolean`\
+Default: `false`
+
+When set, logs explaining the decision will be output to `stderr` whenever the module opts to not print an update notification

--- a/src/hasNewVersion.ts
+++ b/src/hasNewVersion.ts
@@ -8,6 +8,7 @@ const hasNewVersion = async ({
   updateCheckInterval = 1000 * 60 * 60 * 24,
   distTag = 'latest',
   alwaysRun,
+  debug,
 }: IUpdate) => {
   createConfigDir();
   const lastUpdateCheck = getLastUpdate(pkg.name);
@@ -20,7 +21,17 @@ const hasNewVersion = async ({
     saveLastUpdate(pkg.name);
     if (semver.gt(latestVersion, pkg.version)) {
       return latestVersion;
+    } else if (debug) {
+      console.error(
+        `Latest version (${latestVersion}) not newer than current version (${pkg.version})`
+      );
     }
+  } else if (debug) {
+    console.error(
+      `Too recent to check for a new update. simpleUpdateNotifier() interval set to ${updateCheckInterval}ms but only ${
+        new Date().getTime() - lastUpdateCheck
+      }ms since last check.`
+    );
   }
 
   return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ const simpleUpdateNotifier = async (args: IUpdate) => {
     !args.alwaysRun &&
     (!process.stdout.isTTY || (isNpmOrYarn && !args.shouldNotifyInNpmScript))
   ) {
+    if (args.debug) {
+      console.error('Opting out of running simpleUpdateNotifier()');
+    }
     return;
   }
 
@@ -20,8 +23,11 @@ Current Version: ${args.pkg.version}
 Latest Version: ${latestVersion}`)
       );
     }
-  } catch {
+  } catch (err) {
     // Catch any network errors or cache writing errors so module doesn't cause a crash
+    if (args.debug && err instanceof Error) {
+      console.error('Unexpected error in simpleUpdateNotifier():', err);
+    }
   }
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export interface IUpdate {
   shouldNotifyInNpmScript?: boolean;
   distTag?: string;
   alwaysRun?: boolean;
+  debug?: boolean;
 }


### PR DESCRIPTION
Fixes #14

Aim was to add a debug explanation for all cases where an update notification would _not_ be shown. That way one can easily understand whether its due to an error, an incorrect config or actually correct.